### PR TITLE
V9.0.3/package maintenance

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,14 +1,14 @@
-﻿FROM nginx:1.27.3-alpine AS base
+﻿FROM --platform=$BUILDPLATFORM nginx:1.27.5-alpine AS base
 RUN rm -rf /usr/share/nginx/html/*
 
-FROM codebeltnet/docfx:2.77.0 AS build
+FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.3 AS build
 
 ADD [".", "docfx"]
 
 RUN cd docfx; \
     docfx build
 
-FROM base AS final
+FROM nginx:1.27.5-alpine AS final
 WORKDIR /usr/share/nginx/html
 COPY --from=build /build/docfx/wwwroot /usr/share/nginx/html
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -23,108 +23,43 @@ permissions:
 
 jobs:
   build:
-    name: 🛠️ Build
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    name: call-build
     strategy:
       matrix:
         configuration: [Debug, Release]
-        framework: [net9.0,net8.0,netstandard2.0]
-    outputs:
-      version: ${{ steps.minver-calculate.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
-
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Install MinVer
-        uses: codebeltnet/dotnet-tool-install-minver@v1
-
-      - id: minver-calculate
-        name: Calculate Version
-        uses: codebeltnet/minver-calculate@v2
-
-      - name: Download newtonsoft.snk file
-        uses: codebeltnet/gcp-download-file@v1
-        with:
-          serviceAccountKey: ${{ secrets.GCP_TOKEN }}
-          bucketName: ${{ secrets.GCP_BUCKETNAME }}
-          objectName: newtonsoft.snk
-
-      - name: Set environment variable for projects
-        run: |
-          if [ "${{ matrix.framework }}" == "netstandard2.0" ]; then
-            projects=(
-              "src/**/Codebelt.Extensions.Newtonsoft.Json.csproj"
-            )
-            echo "PROJECTS=$(IFS=' '; echo "${projects[*]}")" >> $GITHUB_ENV
-          else
-            echo "PROJECTS=src/**/*.csproj" >> $GITHUB_ENV
-          fi
-        shell: bash
-
-      - name: Restore Dependencies
-        uses: codebeltnet/dotnet-restore@v2
-
-      - name: Build for ${{ matrix.framework }} (${{ matrix.configuration }})
-        uses: codebeltnet/dotnet-build@v2
-        with:
-          projects: ${{ env.PROJECTS }}
-          configuration: ${{ matrix.configuration }}
-          framework: ${{ matrix.framework }}
+    uses: codebeltnet/jobs-dotnet-build/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
+      strong-name-key-filename: newtonsoft.snk
+    secrets:
+      GCP_TOKEN: ${{ secrets.GCP_TOKEN }}
+      GCP_BUCKETNAME: ${{ secrets.GCP_BUCKETNAME }}
 
   pack:
-    name: 📦 Pack
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    name: call-pack
+    needs: [build]
     strategy:
       matrix:
         configuration: [Debug, Release]
-    needs: [build]
-    steps:
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Pack for ${{ matrix.configuration }}
-        uses: codebeltnet/dotnet-pack@v2
-        with:
-          configuration: ${{ matrix.configuration }}
-          uploadPackedArtifact: true
-          version: ${{ needs.build.outputs.version }}
+    uses: codebeltnet/jobs-dotnet-pack/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
+      upload-packed-artifact: true
+      version: ${{ needs.build.outputs.version }}
 
   test:
-    name: 🧪 Test
+    name: call-test
     needs: [build]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-24.04, windows-2022]
         configuration: [Debug, Release]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
-
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Install .NET Tool - Report Generator
-        uses: codebeltnet/dotnet-tool-install-reportgenerator@v1
-
-      - name: Test with ${{ matrix.configuration }} build
-        uses: codebeltnet/dotnet-test@v3
-        with:
-          configuration: ${{ matrix.configuration }}
-          buildSwitches: -p:SkipSignAssembly=true
+    uses: codebeltnet/jobs-dotnet-test/.github/workflows/default.yml@v1
+    with:
+      configuration: ${{ matrix.configuration }}
+      runs-on: ${{ matrix.os }}
+      build-switches: -p:SkipSignAssembly=true
           
   sonarcloud:
     name: call-sonarcloud
@@ -154,8 +89,8 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     name: call-nuget
-    needs: [build,pack,test,sonarcloud,codecov,codeql]
-    uses: codebeltnet/jobs-nuget/.github/workflows/default.yml@v1
+    needs: [build, pack, test, sonarcloud, codecov, codeql]
+    uses: codebeltnet/jobs-nuget-push/.github/workflows/default.yml@v1
     with:
       version: ${{ needs.build.outputs.version }}
       environment: Production

--- a/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.2
+﻿Version 9.0.3
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.2
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.2
+﻿Version 9.0.3
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.2
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Newtonsoft.Json.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Newtonsoft.Json.App/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.2
+﻿Version 9.0.3
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.2
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.2
+﻿Version 9.0.3
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.2
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Newtonsoft.Json, Cuemon.Extensions.AspNetCore.Newtonsoft.Json and Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.
 
+## [9.0.3] - 2025-05-25
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.2] - 2025-04-16
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,17 +3,17 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.0" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.0" />
-    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.4" />
-    <PackageVersion Include="Cuemon.Core" Version="9.0.4" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.4" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.4" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.4" />
-    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.4" />
-    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.4" />
-    <PackageVersion Include="Cuemon.IO" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.1" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.1" />
+    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.5" />
+    <PackageVersion Include="Cuemon.Core" Version="9.0.5" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.5" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.5" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.5" />
+    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.5" />
+    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.5" />
+    <PackageVersion Include="Cuemon.IO" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
@@ -21,12 +21,12 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.15" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.16" />
   </ItemGroup>
 </Project>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.408-9.0.203"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.409-9.0.300"
         }
     ]
 }


### PR DESCRIPTION
This pull request introduces several updates, including dependency upgrades, workflow simplifications, and Dockerfile improvements. The changes focus on modernizing the codebase, improving maintainability, and ensuring compatibility with the latest frameworks and tools.

### Workflow Simplification:
* Consolidated `.github/workflows/pipelines.yml` by replacing custom build, pack, and test steps with reusable workflows (`codebeltnet/jobs-dotnet-build`, `codebeltnet/jobs-dotnet-pack`, `codebeltnet/jobs-dotnet-test`) to simplify maintenance. Updated the `call-nuget` job to use `jobs-nuget-push` instead of `jobs-nuget`. [[1]](diffhunk://#diff-c40697b077557a99813200fa892d01ac2d8c5201799193bc34320cd9526ee802L26-R62) [[2]](diffhunk://#diff-c40697b077557a99813200fa892d01ac2d8c5201799193bc34320cd9526ee802L158-R93)

### Dependency and Version Updates:
* Upgraded multiple package dependencies in `Directory.Packages.props`, including `Cuemon` and `xunit` packages, to their latest versions for improved compatibility and features.
* Updated release notes across multiple packages (`Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json`, `Codebelt.Extensions.AspNetCore.Newtonsoft.Json`, etc.) to reflect the new version `9.0.3` and dependency changes. [[1]](diffhunk://#diff-0e127053864526fee36b9a12f505102935f85ce86c5f5ff083bb70564da00ecfL1-R7) [[2]](diffhunk://#diff-79307047de8606141edda6916ac618c0c5ee786f708e52a66ccbc18cb244cbeaL1-R7) [[3]](diffhunk://#diff-b945640f8c244b20ca6e76cf12e8193ca7d5f0ff1e5858cea5a24926d9e41f9eL1-R7) [[4]](diffhunk://#diff-8f7302a997aa543f1de4a797c1db6d3bde77d9f1f88ba1dd0434fd6657329aceL1-R7)
* Added a new entry for version `9.0.3` in `CHANGELOG.md`, highlighting the focus on package dependency updates.

### Dockerfile Improvements:
* Updated `.docfx/Dockerfile.docfx` to use platform-specific builds and upgraded `nginx` and `docfx` to newer versions (`nginx:1.27.5-alpine` and `codebeltnet/docfx:2.78.3`).

### Test Environment Update:
* Updated the Docker image in `testenvironments.json` to `gimlichael/ubuntu-testrunner:net8.0.409-9.0.300` for compatibility with the latest .NET versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded multiple package dependencies to their latest compatible versions.
  - Updated Docker images and test environments to use newer base versions.
  - Refactored CI workflows for improved modularity and maintainability.
- **Documentation**
  - Added release notes for version 9.0.3, highlighting updated dependencies and framework support.
  - Updated the changelog to include the latest service update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->