### PR TITLE
V9.0.7/service update

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,4 +1,4 @@
-﻿ARG NGINX_VERSION=1.29.0-alpine
+﻿ARG NGINX_VERSION=1.29.1-alpine
 
 FROM --platform=$BUILDPLATFORM nginx:${NGINX_VERSION} AS base
 RUN rm -rf /usr/share/nginx/html/*

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -59,7 +59,8 @@ jobs:
       configuration: ${{ matrix.configuration }}
       runs-on: ${{ matrix.os }}
       build-switches: -p:SkipSignAssembly=true
-      restore: true
+      restore: true # net48 requires restore
+      build: true # net48 requires build
           
   sonarcloud:
     name: call-sonarcloud

--- a/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.6
+﻿Version 9.0.7
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.6
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.6
+﻿Version 9.0.7
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.6
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.6
+﻿Version 9.0.7
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.6
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Newtonsoft.Json, Cuemon.Extensions.AspNetCore.Newtonsoft.Json and Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.
 
+## [9.0.7] - 2025-09-15
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.6] - 2025-08-19
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,16 +3,16 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.5" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.5" />
-    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Core" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.8" />
-    <PackageVersion Include="Cuemon.IO" Version="9.0.8" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.6" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.6" />
+    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Core" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.9" />
+    <PackageVersion Include="Cuemon.IO" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
@@ -24,9 +24,9 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.20" />
   </ItemGroup>
 </Project>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.413-9.0.304"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.414-9.0.305"
         }
     ]
 }


### PR DESCRIPTION
This pull request is a service update focused on keeping package dependencies and related infrastructure up to date. It upgrades several dependencies to their latest compatible versions, updates release notes, and makes minor adjustments to build and test configurations to ensure compatibility with the latest frameworks.

**Dependency updates:**

* Updated all `Cuemon.*` and `Codebelt.*` package versions in `Directory.Packages.props` to their latest releases, including `Microsoft.AspNetCore.Mvc.NewtonsoftJson` for both .NET 9 and .NET 8 target frameworks. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L6-R15) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L27-R30)

**Release notes and documentation:**

* Added release notes for version 9.0.7 in `CHANGELOG.md` and updated `PackageReleaseNotes.txt` files for `Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json`, `Codebelt.Extensions.AspNetCore.Newtonsoft.Json`, and `Codebelt.Extensions.Newtonsoft.Json` to reflect dependency upgrades and framework availability. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R13) [[2]](diffhunk://#diff-0e127053864526fee36b9a12f505102935f85ce86c5f5ff083bb70564da00ecfL1-R7) [[3]](diffhunk://#diff-79307047de8606141edda6916ac618c0c5ee786f708e52a66ccbc18cb244cbeaL1-R7) [[4]](diffhunk://#diff-8f7302a997aa543f1de4a797c1db6d3bde77d9f1f88ba1dd0434fd6657329aceL1-R7)

**Build and test infrastructure:**

* Updated Docker image tag in `testenvironments.json` for the Ubuntu test runner to use the latest .NET 8 and .NET 9 patch versions.
* Bumped NGINX base image version in `.docfx/Dockerfile.docfx` to `1.29.1-alpine`.
* Ensured explicit build and restore steps for net48 in the GitHub Actions workflow (`pipelines.yml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added 9.0.7 release notes across Newtonsoft.Json packages and updated CHANGELOG with dependency updates (no API changes).

- Chores
  - Upgraded central dependencies (Cuemon libraries, Codebelt test packages) and Microsoft.AspNetCore.Mvc.NewtonsoftJson for .NET 9/.NET 8.
  - Bumped NGINX base image to 1.29.1-alpine for documentation site container.
  - Updated test runner Docker image to net8.0.414-9.0.305.
  - CI: Enabled explicit build for net48 in tests and clarified restore step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->