### PR TITLE
V9.0.8/service update

### DIFF
--- a/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.7
+﻿Version 9.0.8
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.7
+﻿Version 9.0.8
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Newtonsoft.Json.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Newtonsoft.Json.App/PackageReleaseNotes.txt
@@ -1,4 +1,16 @@
-﻿Version 9.0.6
+﻿Version 9.0.8
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.6
 Availability: .NET 9 and .NET 8
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿Version 9.0.7
+﻿Version 9.0.8
+Availability: .NET 9, .NET 8 and .NET Standard 2.0
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+Version 9.0.7
 Availability: .NET 9, .NET 8 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Newtonsoft.Json, Cuemon.Extensions.AspNetCore.Newtonsoft.Json and Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.
 
+## [9.0.8] - 2025-10-20
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.7] - 2025-09-15
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,30 +3,29 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.6" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.6" />
-    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Core" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.9" />
-    <PackageVersion Include="Cuemon.IO" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit" Version="10.0.7" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.7" />
+    <PackageVersion Include="Cuemon.AspNetCore.Mvc" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Core" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Authentication" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.AspNetCore.Mvc" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.Extensions.IO" Version="9.0.10" />
+    <PackageVersion Include="Cuemon.IO" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.21" />
   </ItemGroup>
 </Project>

--- a/test/Codebelt.Extensions.Newtonsoft.Json.Tests/Codebelt.Extensions.Newtonsoft.Json.Tests.csproj
+++ b/test/Codebelt.Extensions.Newtonsoft.Json.Tests/Codebelt.Extensions.Newtonsoft.Json.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.414-9.0.305"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.415-9.0.306"
         }
     ]
 }


### PR DESCRIPTION
This pull request is a service update focused on upgrading package dependencies across the project to their latest compatible versions. It updates dependency versions in both the release notes and project files, ensuring continued compatibility with supported .NET target frameworks.

Dependency upgrades:

* Updated all major internal and external package dependencies to their latest compatible versions in `Directory.Packages.props`, including `Cuemon.*`, `Codebelt.Extensions.Xunit`, `Newtonsoft.Json`, `Microsoft.NET.Test.Sdk`, and others. (.NET 8/9 compatibility maintained)
* Updated the Docker test runner image in `testenvironments.json` to use a newer version for .NET 8 and .NET 9 testing.

Release notes and changelog:

* Added release notes for version 9.0.8 to all relevant `PackageReleaseNotes.txt` files, documenting the dependency upgrades and supported target frameworks. [[1]](diffhunk://#diff-0e127053864526fee36b9a12f505102935f85ce86c5f5ff083bb70564da00ecfL1-R7) [[2]](diffhunk://#diff-79307047de8606141edda6916ac618c0c5ee786f708e52a66ccbc18cb244cbeaL1-R7) [[3]](diffhunk://#diff-b945640f8c244b20ca6e76cf12e8193ca7d5f0ff1e5858cea5a24926d9e41f9eL1-R13) [[4]](diffhunk://#diff-8f7302a997aa543f1de4a797c1db6d3bde77d9f1f88ba1dd0434fd6657329aceL1-R7)
* Updated `CHANGELOG.md` to include an entry for version 9.0.8, highlighting the focus on package dependencies.

Build/test configuration:

* Changed the way `System.Net.Http` is referenced in the .NET Framework test project to use a direct assembly reference instead of a package reference, improving compatibility.
[Copilot is generating a summary...]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Released Version 9.0.8 for .NET 8, .NET 9, and .NET Standard 2.0 availability
  * Updated package dependencies to latest compatible versions
  * Updated test environment and tooling versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->