### PR TITLE
V10.1.0/minimal api support

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -3,7 +3,7 @@
 FROM --platform=$BUILDPLATFORM nginx:${NGINX_VERSION} AS base
 RUN rm -rf /usr/share/nginx/html/*
 
-FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.4 AS build
+FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.5 AS build
 
 ADD [".", "docfx"]
 

--- a/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,4 @@
-Version: 10.0.4
+Version: 10.1.0
 Availability: .NET 10 and .NET 9
  
 # ALM

--- a/.nuget/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,8 +1,14 @@
-Version: 10.0.4
+Version: 10.1.0
 Availability: .NET 10 and .NET 9
  
 # ALM
 - CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
+# New Features
+- ADDED ServiceCollectionExtensions class in the Codebelt.Extensions.AspNetCore.Newtonsoft.Json namespace with AddMinimalNewtonsoftJsonOptions method
+ 
+# Improvements
+- CHANGED ServiceCollectionExtensions class in the Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Formatters namespace so AddNewtonsoftJsonFormatterOptions uses TryConfigure to avoid duplicate option registrations
  
 Version: 10.0.3
 Availability: .NET 10 and .NET 9

--- a/.nuget/Codebelt.Extensions.Newtonsoft.Json.App/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Newtonsoft.Json.App/PackageReleaseNotes.txt
@@ -1,4 +1,4 @@
-Version: 10.0.4
+Version: 10.1.0
 Availability: .NET 10 and .NET 9
  
 # ALM

--- a/.nuget/Codebelt.Extensions.Newtonsoft.Json/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.Newtonsoft.Json/PackageReleaseNotes.txt
@@ -1,4 +1,4 @@
-Version: 10.0.4
+Version: 10.1.0
 Availability: .NET 10, .NET 9 and .NET Standard 2.0
  
 # ALM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.Newtonsoft.Json, Cuemon.Extensions.AspNetCore.Newtonsoft.Json and Cuemon.Extensions.AspNetCore.Mvc.Formatters.Newtonsoft.Json.
 
-## [10.0.4] - 2026-02-28
+## [10.1.0] - 2026-02-28
 
-This is a service update that focuses on package dependencies.
+This is a minor release that improves minimal API formatter integration, while also tightening option registration behavior across ASP.NET Core formatter setup.
+
+### Added
+
+- `ServiceCollectionExtensions` class in the Codebelt.Extensions.AspNetCore.Newtonsoft.Json namespace was extended with a new method: `AddMinimalNewtonsoftJsonOptions`.
+
+### Changed
+
+- `ServiceCollectionExtensions` class in the Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Formatters namespace to use TryConfigure in `AddNewtonsoftJsonFormatterOptions`.
+
+### Fixed
+
+- Prevented repeated `IConfigureOptions<TOptions>` registrations when formatter/options extension methods are called multiple times.
 
 ## [10.0.3] - 2026-02-20
 

--- a/src/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/Formatters/ServiceCollectionExtensions.cs
+++ b/src/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/Formatters/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Converters;
 using Codebelt.Extensions.Newtonsoft.Json.Formatters;
 using Cuemon;
 using Cuemon.AspNetCore.Diagnostics;
+using Cuemon.Extensions.DependencyInjection;
 using Cuemon.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -37,7 +38,7 @@ namespace Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Formatters
         {
             Validator.ThrowIfNull(services);
             Validator.ThrowIfInvalidConfigurator(setup, out var options);
-            services.Configure(setup ?? (o =>
+            services.TryConfigure(setup ?? (o =>
             {
                 o.Settings = options.Settings;
                 o.SensitivityDetails = options.SensitivityDetails;

--- a/src/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/ServiceCollectionExtensions.cs
+++ b/src/Codebelt.Extensions.AspNetCore.Newtonsoft.Json/ServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Formatters;
+using Codebelt.Extensions.Newtonsoft.Json.Formatters;
+using Cuemon;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Codebelt.Extensions.AspNetCore.Newtonsoft.Json
+{
+    /// <summary>
+    /// Extension methods for the <see cref="IServiceCollection"/> interface.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds a <see cref="NewtonsoftJsonFormatterOptions"/> service to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <param name="setup">The <see cref="NewtonsoftJsonFormatterOptions"/> which may be configured.</param>
+        /// <returns>An <see cref="IServiceCollection"/> that can be used to further configure other services.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> cannot be null.
+        /// </exception>
+        public static IServiceCollection AddMinimalNewtonsoftJsonOptions(this IServiceCollection services, Action<NewtonsoftJsonFormatterOptions> setup = null)
+        {
+            Validator.ThrowIfNull(services);
+            return services.AddNewtonsoftJsonExceptionResponseFormatter(setup);
+        }
+    }
+}

--- a/test/Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Tests/Formatters/ServiceCollectionExtensionsTest.cs
+++ b/test/Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Tests/Formatters/ServiceCollectionExtensionsTest.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Codebelt.Extensions.Newtonsoft.Json.Formatters;
 using Codebelt.Extensions.Xunit;
 using Codebelt.Extensions.Xunit.Hosting.AspNetCore;
 using Cuemon.AspNetCore.Authentication.Basic;
@@ -16,6 +18,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
@@ -301,6 +304,78 @@ namespace Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Formatters
                                  """.ReplaceLineEndings(), content.ReplaceLineEndings());
                 }
             }
+        }
+
+        [Fact]
+        public void AddNewtonsoftJsonFormatterOptions_ShouldThrowArgumentNullException_WhenServicesIsNull()
+        {
+            IServiceCollection services = null;
+
+            var sut = Assert.Throws<ArgumentNullException>(() => services.AddNewtonsoftJsonFormatterOptions());
+
+            Assert.Equal("services", sut.ParamName);
+        }
+
+        [Fact]
+        public void AddNewtonsoftJsonFormatterOptions_ShouldRegisterOptionsWithDefaultValues()
+        {
+            var services = new ServiceCollection();
+            services.AddNewtonsoftJsonFormatterOptions();
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<NewtonsoftJsonFormatterOptions>>();
+
+            Assert.NotNull(options.Value.Settings);
+            Assert.NotNull(options.Value.SupportedMediaTypes);
+            Assert.Equal(FaultSensitivityDetails.None, options.Value.SensitivityDetails);
+            Assert.False(options.Value.SynchronizeWithJsonConvert);
+        }
+
+        [Fact]
+        public void AddNewtonsoftJsonFormatterOptions_ShouldApplySetupConfiguration()
+        {
+            var services = new ServiceCollection();
+            services.AddNewtonsoftJsonFormatterOptions(o => o.SensitivityDetails = FaultSensitivityDetails.All);
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<NewtonsoftJsonFormatterOptions>>();
+
+            Assert.Equal(FaultSensitivityDetails.All, options.Value.SensitivityDetails);
+        }
+
+        [Fact]
+        public void AddNewtonsoftJsonFormatterOptions_ShouldOnlyRegisterOnce_WhenCalledMultipleTimes()
+        {
+            var services = new ServiceCollection();
+            services.AddNewtonsoftJsonFormatterOptions(o => o.SensitivityDetails = FaultSensitivityDetails.All);
+            services.AddNewtonsoftJsonFormatterOptions(o => o.SensitivityDetails = FaultSensitivityDetails.Evidence);
+
+            var count = services.Count(s => s.ServiceType == typeof(IConfigureOptions<NewtonsoftJsonFormatterOptions>));
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void AddNewtonsoftJsonExceptionResponseFormatter_ShouldThrowArgumentNullException_WhenServicesIsNull()
+        {
+            IServiceCollection services = null;
+
+            var sut = Assert.Throws<ArgumentNullException>(() => services.AddNewtonsoftJsonExceptionResponseFormatter());
+
+            Assert.Equal("services", sut.ParamName);
+        }
+
+        [Fact]
+        public void AddNewtonsoftJsonExceptionResponseFormatter_ShouldRegisterFormatter()
+        {
+            var services = new ServiceCollection();
+            services.AddFaultDescriptorOptions();
+            services.AddNewtonsoftJsonExceptionResponseFormatter();
+
+            var sp = services.BuildServiceProvider();
+            var formatter = sp.GetService<HttpExceptionDescriptorResponseFormatter<NewtonsoftJsonFormatterOptions>>();
+
+            Assert.NotNull(formatter);
         }
 
     }

--- a/test/Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Tests/ServiceCollectionExtensionsTest.cs
+++ b/test/Codebelt.Extensions.AspNetCore.Newtonsoft.Json.Tests/ServiceCollectionExtensionsTest.cs
@@ -1,0 +1,66 @@
+using System;
+using Codebelt.Extensions.Newtonsoft.Json.Formatters;
+using Codebelt.Extensions.Xunit;
+using Cuemon.AspNetCore.Diagnostics;
+using Cuemon.Diagnostics;
+using Cuemon.Extensions.AspNetCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Codebelt.Extensions.AspNetCore.Newtonsoft.Json
+{
+    public class ServiceCollectionExtensionsTest : Test
+    {
+        public ServiceCollectionExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void AddMinimalNewtonsoftJsonOptions_ShouldThrowArgumentNullException_WhenServicesIsNull()
+        {
+            IServiceCollection services = null;
+
+            var sut = Assert.Throws<ArgumentNullException>(() => services.AddMinimalNewtonsoftJsonOptions());
+
+            Assert.Equal("services", sut.ParamName);
+        }
+
+        [Fact]
+        public void AddMinimalNewtonsoftJsonOptions_ShouldReturnSameServiceCollection()
+        {
+            var services = new ServiceCollection();
+            services.AddFaultDescriptorOptions();
+
+            var result = services.AddMinimalNewtonsoftJsonOptions();
+
+            Assert.Same(services, result);
+        }
+
+        [Fact]
+        public void AddMinimalNewtonsoftJsonOptions_ShouldRegisterNewtonsoftJsonExceptionResponseFormatter()
+        {
+            var services = new ServiceCollection();
+            services.AddFaultDescriptorOptions();
+            services.AddMinimalNewtonsoftJsonOptions();
+
+            var sp = services.BuildServiceProvider();
+            var formatter = sp.GetService<HttpExceptionDescriptorResponseFormatter<NewtonsoftJsonFormatterOptions>>();
+
+            Assert.NotNull(formatter);
+        }
+
+        [Fact]
+        public void AddMinimalNewtonsoftJsonOptions_ShouldConfigureOptions_WhenSetupIsProvided()
+        {
+            var services = new ServiceCollection();
+            services.AddFaultDescriptorOptions();
+            services.AddMinimalNewtonsoftJsonOptions(o => o.SensitivityDetails = FaultSensitivityDetails.All);
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetRequiredService<IOptions<NewtonsoftJsonFormatterOptions>>();
+
+            Assert.Equal(FaultSensitivityDetails.All, options.Value.SensitivityDetails);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a minor release (10.1.0) focused on improving minimal API formatter integration and tightening option registration for ASP.NET Core formatter setup. It adds a new extension method for minimal configuration, ensures option registrations are not duplicated, and updates dependencies. The changes are documented and thoroughly tested.

**New Features and Improvements**

* Added a new `ServiceCollectionExtensions` class in the `Codebelt.Extensions.AspNetCore.Newtonsoft.Json` namespace, providing the `AddMinimalNewtonsoftJsonOptions` method to simplify minimal API formatter setup. [[1]](diffhunk://#diff-e09b2e6087169c9637eadc360ec2f7aa576d935cacaed40f8f069702d477f5f4R1-R29) [[2]](diffhunk://#diff-79307047de8606141edda6916ac618c0c5ee786f708e52a66ccbc18cb244cbeaL1-R12) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL10-R24)
* Updated the `AddNewtonsoftJsonFormatterOptions` method in `ServiceCollectionExtensions` (Formatters) to use `TryConfigure`, preventing duplicate option registrations and improving robustness when called multiple times. [[1]](diffhunk://#diff-f783d8f99b642da8a8a90fc33387c4fdb1f2884912d9593cda27956d11ca3726L40-R41) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL10-R24)

**Dependency and Version Updates**

* Upgraded the DocFX build image from version 2.78.4 to 2.78.5 in `.docfx/Dockerfile.docfx`.
* Bumped package versions to 10.1.0 and updated release notes across all relevant `PackageReleaseNotes.txt` files, documenting new features and improvements. [[1]](diffhunk://#diff-0e127053864526fee36b9a12f505102935f85ce86c5f5ff083bb70564da00ecfL1-R1) [[2]](diffhunk://#diff-79307047de8606141edda6916ac618c0c5ee786f708e52a66ccbc18cb244cbeaL1-R12) [[3]](diffhunk://#diff-b945640f8c244b20ca6e76cf12e8193ca7d5f0ff1e5858cea5a24926d9e41f9eL1-R1) [[4]](diffhunk://#diff-8f7302a997aa543f1de4a797c1db6d3bde77d9f1f88ba1dd0434fd6657329aceL1-R1)

**Testing Enhancements**

* Added comprehensive unit tests for both the new `AddMinimalNewtonsoftJsonOptions` method and the improved formatter options registration, ensuring correct behavior, error handling, and prevention of duplicate registrations. [[1]](diffhunk://#diff-c1de733540469f32196170d881c3ec9255e99f6e00096a58f18e64646179b845R1-R66) [[2]](diffhunk://#diff-8923b4f76e8b12e88521b800cf4c49c227f2e5a6b748e690e3f36c385ec976b2R309-R380)

**Documentation**

* Updated `CHANGELOG.md` to reflect new features, changes, and fixes in version 10.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `AddMinimalNewtonsoftJsonOptions` extension method for streamlined Newtonsoft JSON formatter configuration in ASP.NET Core.

* **Bug Fixes**
  * Prevented duplicate `IConfigureOptions` registrations when formatter option methods are invoked repeatedly.

* **Chores**
  * Bumped package versions to 10.1.0.
  * Updated build dependencies and release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->